### PR TITLE
fix: prevent sidebar login button from being hidden on short viewports

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -70,8 +70,8 @@ function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
 
 function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
   return (
-    <div className="flex h-full flex-col">
-      <nav className="flex-1 overflow-auto py-4">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <nav className="min-h-0 flex-1 overflow-auto py-4">
         <NavLinks onNavigate={onNavigate} />
       </nav>
       <div className="px-6 pt-4">


### PR DESCRIPTION
Changed SidebarContent wrapper from `h-full` to `flex-1 min-h-0` so it takes remaining space after the logo instead of 100% of the parent. Added `min-h-0` to the nav so it can shrink below its content height and properly scroll.

This keeps the Google login button pinned at the bottom of the sidebar regardless of viewport height.