### PR TITLE
Raise asset upload size limit to 50MB

### DIFF
--- a/src/components/AssetBrowser.tsx
+++ b/src/components/AssetBrowser.tsx
@@ -249,7 +249,7 @@ export function AssetBrowser({ initialPath = '/' }: AssetBrowserProps) {
     if (!files || files.length === 0) return;
 
     const MAX_FILES = 50;
-    const MAX_SIZE_MB = 25;
+    const MAX_SIZE_MB = 50;
     const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
 
     // Check file count limit
@@ -618,7 +618,7 @@ export function AssetBrowser({ initialPath = '/' }: AssetBrowserProps) {
       </div>
 
       <div className="text-muted-foreground bg-muted/50 rounded-md px-3 py-2 text-sm">
-        <span className="font-medium">Note:</span> Maximum file size is 25 MB.
+        <span className="font-medium">Note:</span> Maximum file size is 50 MB.
         All uploaded files are publicly accessible to everyone.
       </div>
 

--- a/src/components/ImagePickerModal.tsx
+++ b/src/components/ImagePickerModal.tsx
@@ -26,7 +26,7 @@ interface ImagePickerModalProps {
   folderPath?: string;
 }
 
-const MAX_SIZE_BYTES = 25 * 1024 * 1024;
+const MAX_SIZE_BYTES = 50 * 1024 * 1024;
 
 function joinPath(basePath: string, name: string): string {
   if (basePath === '/') return `/${name}`;
@@ -216,7 +216,7 @@ function UploadTab({
 
     if (file.size > MAX_SIZE_BYTES) {
       setError(
-        `File exceeds 25 MB limit (${(file.size / 1024 / 1024).toFixed(1)} MB)`,
+        `File exceeds 50 MB limit (${(file.size / 1024 / 1024).toFixed(1)} MB)`,
       );
       e.target.value = '';
       return;
@@ -289,7 +289,7 @@ function UploadTab({
           {uploading ? 'Uploading...' : 'Click to upload an image'}
         </p>
         <p className="text-muted-foreground mt-1 text-xs">
-          Max file size: 25 MB
+          Max file size: 50 MB
         </p>
       </div>
 


### PR DESCRIPTION
Raises the max asset upload size in the Asset Browser from 25MB to 50MB to accommodate audio files like the radio interview recording (~41MB).

- `AssetBrowser.tsx`: `MAX_SIZE_MB` 25 → 50 and updated UI note text